### PR TITLE
Revert "Fix 0.4-dev dlopen breakage, Fix #143"

### DIFF
--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -28,14 +28,6 @@ if VERSION >= v"0.4.0-dev+3710"
 else
     const unsafe_convert = Base.convert
 end
-# This is not the exact version but should be closed enough
-if VERSION >= v"0.4.0-dev+4922"
-    typealias HandleT Union(Libdl.DLHandle, Ptr{Void})
-    hdl_ptr(hdl::Libdl.DLHandle) = hdl.ptr
-else
-    typealias HandleT Ptr{Void}
-end
-hdl_ptr(hdl::Ptr{Void}) = hdl
 
 #########################################################################
 


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/11563 reverted https://github.com/JuliaLang/julia/pull/11293, so a497bf989c4b559d005607c0580dd59acab5fe19 needs to be reverted as well for PyCall to continue working on Julia nightly. At present the package load fails because `Libdl.DLHandle` no longer exists.

This will leave PyCall broken on versions of Julia nightly between those two commits.