### PR TITLE
Use v0.4 Timer API

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.3
-Compat 0.4
+Compat 0.4.6
 Dates

--- a/src/gui.jl
+++ b/src/gui.jl
@@ -144,7 +144,11 @@ function Tk_eventloop(sec::Real=50e-3)
     install_doevent(doevent, sec)
 end
 # cache running event loops (so that we don't start any more than once)
-const eventloops = Dict{Symbol,Timer}()
+if VERSION < v"0.4.0-dev+5322"
+    const eventloops = Dict{Symbol,Compat.Timer2}()
+else
+    const eventloops = Dict{Symbol,Timer}()
+end
 
 function pygui_start(gui::Symbol=pygui(), sec::Real=50e-3)
     pygui(gui)

--- a/src/gui.jl
+++ b/src/gui.jl
@@ -62,8 +62,7 @@ end
 
 # call doevent(status) every sec seconds
 function install_doevent(doevent::Function, sec::Real)
-    timeout = Base.Timer(doevent)
-    Base.start_timer(timeout,sec,sec)
+    timeout = Base.Timer(doevent,sec,sec)
     return timeout
 end
 
@@ -177,7 +176,7 @@ end
 
 function pygui_stop(gui::Symbol=pygui())
     if haskey(eventloops, gui)
-        Base.stop_timer(pop!(eventloops, gui))
+        Base.close(pop!(eventloops, gui))
         true
     else
         false


### PR DESCRIPTION
This should address stevengj/PyPlot.jl#136 as well.

I don't know of a clean way of making `Dict{Symbol,Timer}()` compatible with the new timer API, so an if-statement will have to do for now.  `@compat` seems to only work on Timer type declarations, not the type itself.
