### PR TITLE
Updated timer methods to 0.4-dev

### DIFF
--- a/src/gui.jl
+++ b/src/gui.jl
@@ -62,8 +62,12 @@ end
 
 # call doevent(status) every sec seconds
 function install_doevent(doevent::Function, sec::Real)
-    timeout = Base.Timer(doevent)
-    Base.start_timer(timeout,sec,sec)
+    if VERSION >=v"0.4.0-dev+5390"
+        timeout = Base.Timer(doevent,sec,sec)
+    else
+        timeout = Base.Timer(doevent)
+        Base.start_timer(timeout,sec,sec)
+    end
     return timeout
 end
 


### PR DESCRIPTION
Timer methods were recently changed so that start_timer call isn't used:

https://github.com/JuliaLang/julia/pull/11669

I actually don't know how to find the exact version where that change took place, but I think that it is "0.4.0-dev+5390"