### PR TITLE
Fix incorrect usage of NTuple

### DIFF
--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -390,7 +390,7 @@ end
 
 #########################################################################
 
-typealias TypeTuple Union(Type,NTuple{Type})
+typealias TypeTuple{N} Union(Type,NTuple{N, Type})
 
 function pycall(o::PyObject, returntype::TypeTuple, args...; kwargs...)
     oargs = map(PyObject, args)

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -152,7 +152,7 @@ end
 pyptr_query(po::PyObject) = pyisinstance(po, c_void_p_Type) || pyisinstance(po, PyCObject_Type) || pyisinstance(po, PyCapsule_Type) ? Ptr{Void} : None
 
 #########################################################################
-# for automatic conversions, I pass Vector{PyAny}, NTuple{PyAny}, etc.,
+# for automatic conversions, I pass Vector{PyAny}, NTuple{N, PyAny}, etc.,
 # but since PyAny is an abstract type I need to convert this to Any
 # before actually creating the Julia object
 
@@ -204,7 +204,7 @@ function PyObject(t::Tuple)
 end
 
 if VERSION < v"0.4.0-dev+4319" # prior to 0.4 tuple-type changes
-    function convert(tt::NTuple{Type}, o::PyObject)
+    function convert{N}(tt::NTuple{N, Type}, o::PyObject)
         len = @pycheckz ccall((@pysym :PySequence_Size), Int, (PyPtr,), o)
         if len != length(tt)
             throw(BoundsError())


### PR DESCRIPTION
Ref https://github.com/JuliaLang/julia/pull/11969

I know it's really tempting but unfortunately this is not the correct usage of `NTuple`.

```julia
julia> (Int, 1)::NTuple{Type}
(Int64,1)

julia> (Int, Float64)::NTuple{Type}
(Int64,Float64)

julia> (Int, Float64)::NTuple{TypeVar(:N), Type}
(Int64,Float64)

julia> (Int, 1)::NTuple{TypeVar(:N), Type}
ERROR: TypeError: typeassert: expected NTuple{N,Type{T}}, got Tuple{DataType,Int64}
```
