### PR TITLE
Fix error in deps/build.jl due to calling pop!(ENV, "PYTHONHOME") twice.

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -205,6 +205,6 @@ end
 finally # restore env vars
 
 PYTHONIOENCODING != nothing ? (ENV["PYTHONIOENCODING"] = PYTHONIOENCODING) : pop!(ENV, "PYTHONIOENCODING")
-PYTHONHOME != nothing ? (ENV["PYTHONHOME"] = PYTHONHOME) : pop!(ENV, "PYTHONHOME")
+PYTHONHOME != nothing ? (ENV["PYTHONHOME"] = PYTHONHOME) : pop!(ENV, "PYTHONHOME", "")
 
 end


### PR DESCRIPTION
When running `Pkg.build("PyCall")` on my machine, it seems that `pop!(ENV, "PYTHONHOME")` is called twice, thus failing the second time. This PR simply adds a default argument to the second call.

I'm also having issues with the build script properly finding my `PYTHONHOME` in a virtualenv, so the problem fixed here is probably related to that.

Before
```julia
              _
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: http://docs.julialang.org
   _ _   _| |_  __ _   |  Type "?help" for help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.4.0-pre+7393 (2015-09-08 15:09 UTC)
 _/ |\__'_|_|_|\__'_|  |  Commit 8161026 (0 days old master)
|__/                   |  x86_64-apple-darwin14.4.0

julia> Pkg.build("PyCall")
INFO: Building PyCall
INFO: PyCall is using python (Python 2.7.10) at /Users/rasmus/.virtualenvs/main/bin/python, libpython = /usr/local/Cellar/python/2.7.10_2/Frameworks/Python.framework/Versions/2.7/Python
=======================================================================[ ERROR: PyCall ]========================================================================

LoadError: KeyError: PYTHONHOME not found
while loading /Users/rasmus/.julia/v0.4/PyCall/deps/build.jl, in expression starting on line 16

================================================================================================================================================================

========================================================================[ BUILD ERRORS ]========================================================================

WARNING: PyCall had build errors.

 - packages with build errors remain installed in /Users/rasmus/.julia/v0.4
 - build the package(s) and all dependencies with `Pkg.build("PyCall")`
 - build a single package by running its `deps/build.jl` script

================================================================================================================================================================
```

After
```julia
julia> Pkg.build("PyCall")
INFO: Building PyCall
INFO: PyCall is using python (Python 2.7.10) at /Users/rasmus/.virtualenvs/main/bin/python, libpython = /usr/local/Cellar/python/2.7.10_2/Frameworks/Python.framework/Versions/2.7/Python
```