### PR TITLE
fixed deprecated use of pipe -> pipeline

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -66,7 +66,7 @@ function find_libpython(python::AbstractString)
         ENV["PYTHONHOME"] = @windows? exec_prefix : pysys(python, "prefix") * ":" * exec_prefix
         # Unfortunately, setting PYTHONHOME screws up Canopy's Python distro?
         try
-            run(pipe(`$python -c "import site"`, stdout=DevNull, stderr=DevNull))
+            run(pipeline(`$python -c "import site"`, stdout=DevNull, stderr=DevNull))
         catch
             pop!(ENV, "PYTHONHOME")
         end


### PR DESCRIPTION
pipe fails silently with a failure to find method call in try/catch
As a result, PYTHONHOME is improperly set and `import site` fails