### PR TITLE
fixed typo in pyincref

### DIFF
--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -82,7 +82,7 @@ function pydecref(o::PyObject)
 end
 
 function pyincref(o::PyObject)
-    ccall((@pysym :Py_IncRef), Void, (PyPtr,), o)
+    ccall((@pysym :Py_IncRef), Void, (PyPtr,), o.o)
     o
 end
 


### PR DESCRIPTION
This is a typo, right? Now matches pydecref.