### PR TITLE
Update conversions.jl

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -709,8 +709,8 @@ function PyObject(i::BigInt)
 end
 
 function convert(::Type{BigInt}, o::PyObject)
-    BigInt(convert(AbstractString, PyObject(ccall((@pysym :PyObject_Str),
-                                          PyPtr, (PyPtr,), o))))
+    parse(BigInt, (convert(AbstractString, PyObject(ccall((@pysym :PyObject_Str),
+                                          PyPtr, (PyPtr,), o)))))
 end
 
 #########################################################################

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -709,8 +709,8 @@ function PyObject(i::BigInt)
 end
 
 function convert(::Type{BigInt}, o::PyObject)
-    parse(BigInt, (convert(AbstractString, PyObject(ccall((@pysym :PyObject_Str),
-                                          PyPtr, (PyPtr,), o)))))
+    parse(BigInt, convert(AbstractString, PyObject(ccall((@pysym :PyObject_Str),
+                                          PyPtr, (PyPtr,), o))))
 end
 
 #########################################################################


### PR DESCRIPTION
Fixes

```
WARNING: BigInt(s::AbstractString) is deprecated, use parse(BigInt,s) instead.
 in depwarn at deprecated.jl:73
 in call at deprecated.jl:50
 in convert at /Users/bromberger1/.julia/v0.4/PyCall/src/conversions.jl:712
```