### PR TITLE
Support Python 3.5 (and its @ operator - the "dedicated infix …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
     - 2.7
     - 3.2
     - 3.3
+    - 3.5
 compiler:
   - clang
 env:


### PR DESCRIPTION
…operator for matrix multiplication")

http://legacy.python.org/dev/peps/pep-0465/

[TL;DR Feel free to ignore.. I do not want to take up time, just thought 3.5 might have been overlooked/not known.. If not drop some other 3.x?]

I suppose the @ operator already works (maybe tests are needed?).. I'm not pushing for supporting it or anything else new in 3.5, mostly wandering if anything needs supporting and/or if in general latest release needs/should to be tested against".

https://www.python.org/downloads/release/python-336/
"Release Date: 2014-10-12

This is a security-fix source-only release. The last binary release was 3.3.5."

https://www.python.org/downloads/release/python-326/
"Release Date: 2014-10-12

This is a security-fix source-only release. The last binary release was 3.2.5."

Maybe you do not want too test against to many versions?

It's unclear to me if Python 3.2, 3.3 are EOLed (can either/both be dropped?); if they need testing and or 3.4 (just skip that one?):

https://www.python.org/downloads/release/python-336/
"Release Date: 2014-10-12

This is a security-fix source-only release. The last binary release was 3.3.5."


Not important (to me), just an example I found:

https://wiki.openstack.org/wiki/Python3#Python_2:_Python_2.6_support_dropped.2C_Python_2.7_only
"OpenStack Liberty targets Python 2.7 and 3.4.
[..]
Python 3.3 support is being dropped since OpenStack Liberty."

I'm not even sure how many use any 3.x with Julia but it seems we want to support/test with 2.7 for a while more..:

http://blog.startifact.com/posts/the-call-of-python-28.html
"Python 2.7 is still massively popular: the end of life date for Python 2.7 was changed by Guido to 2020 (it was 2015). In the same change he felt he should repeat there will be no Python 2.8"