### PR TITLE
Python 2.6 is not supported, then travis testing should be skipped? [ci skip]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-    - 2.6
     - 2.7
     - 3.2
     - 3.3


### PR DESCRIPTION
According to README at least