### PR TITLE
Work around LLVM error

### DIFF
--- a/src/pyinit.jl
+++ b/src/pyinit.jl
@@ -91,8 +91,8 @@ function __init__()
     global const jl_TextIO_methods = make_io_methods(true)
     global const jl_IO_methods = make_io_methods(false)
     global const jl_IO_getset = PyGetSetDef[
-            PyGetSetDef("closed", jl_IO_closed)
-            PyGetSetDef("encoding", jl_IO_encoding)
+            PyGetSetDef("closed", jl_IO_closed),
+            PyGetSetDef("encoding", jl_IO_encoding),
             PyGetSetDef()
     ]
 


### PR DESCRIPTION
As per my reduced repro in JuliaLang/julia#15533, turning a `vcat` into `vect` causes the error to disappear. **This is totally a dirty hack and workaround, there's absolutely no good reason (AFAIK) that the two version should be different**.

At least this seems to be able to fix the symptom on 4 different version of julia (0.5.0-dev+3106, 0.5.0-dev+3177, 0.5.0-dev+3080, 0.5.0-dev+3143) on 3 different architectures (arm, aarch64, x64) before @vtjnash [fixes](https://github.com/JuliaLang/julia/issues/15533#issuecomment-197906618) the underlying issue....
