### PR TITLE
correct deprecated function

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
 This package provides a `@pyimport` macro that mimics a Python
 `import` statement: it imports a Python module and provides Julia
 wrappers for all of the functions and constants therein, including
-automatic conversion of types between Julia and Python.
+automatic conversion of types between Julia and Python and defining
+new Python classes from Julia methods.
 
 It also provides facilities for lower-level manipulation of Python
 objects, including a `PyObject` type for opaque Python objects and a
@@ -367,7 +368,7 @@ is essentially equivalent to the following Python code:
 
 The method arguments and return values are automatically converted between Julia and Python. All Python special methods are supported (`__len__`, `__add__`, etc.).
 
-`@pydef` allows for multiple inheritance of Python types:
+`@pydef` allows for multiple inheritance of Python classes:
 
     @pydef type SomeType <: (BaseClass1, BaseClass2)
         ...

--- a/README.md
+++ b/README.md
@@ -345,20 +345,19 @@ For instance,
     @pyimport numpy.polynomial as P
     @pydef type Doubler <: P.Polynomial
         __init__(self, x=10) = (self[:x] = x)
-        my_method(self, arg1=5) = arg1 + 20  # the right-hand-side is Julia code
+        my_method(self, arg1::Number) = arg1 + 20
         x2.get(self) = self[:x] * 2
-        x2.set!(self, new_x::Int) = (self[:x] = new_x / 2)
+        x2.set!(self, new_val) = (self[:x] = new_val / 2)
     end
     Doubler()[:x2]
 
-is equivalent to the following Python code:
+is essentially equivalent to the following Python code:
 
     import numpy.polynomial
     class Doubler(numpy.polynomial.Polynomial):
         def __init__(self, x=10):
             self.x = x
-        def my_method(self, arg1):
-            return arg1 + 20
+        def my_method(self, arg1): return arg1 + 20
         @property
         def x2(self): return self.x * 2
         @x2.setter
@@ -366,8 +365,7 @@ is equivalent to the following Python code:
             self.x = new_val / 2
     Doubler().x2
 
-The method arguments and return values are automatically converted. All Python
-special methods are supported (`__len__`, `__add__`, etc.).
+The method arguments and return values are automatically converted between Julia and Python. All Python special methods are supported (`__len__`, `__add__`, etc.).
 
 `@pydef` allows for multiple inheritance of Python types:
 

--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ The solution is fairly simple:
 
 * Python objects that you create in functions called *after* the module is loaded are always safe.
 
-* If you want to store a Python object in a global variable that is initialized automatically when the module is loaded, then initialize the variable in your module's `__init__` function.  For a type-safe global constant, initialize the constant to `PyNull()` at the top level, and then use the `copy!` function in your module's `__init__` function to mutate it to its actual value.
+* If you want to store a Python object in a global variable that is initialized automatically when the module is loaded, then initialize the variable in your module's `__init__` function.  For a type-stable global constant, initialize the constant to `PyNull()` at the top level, and then use the `copy!` function in your module's `__init__` function to mutate it to its actual value.
 
 For example, suppose your module uses the `scipy.optimize` module, and you want to load this module when your module is loaded and store it in a global constant `scipy_opt`.  You could do:
 

--- a/README.md
+++ b/README.md
@@ -337,6 +337,63 @@ For example, calling `f(x, function=g)` will fail because `function` is
 a reserved word in Julia. In such cases, you can use the lower-level
 Julia syntax `f(x; :function=>g)`.
 
+### Defining Python Classes
+
+`@pydef` creates a Python class whose methods are implemented in Julia.
+For instance,
+    
+    @pyimport numpy.polynomial as P
+
+    @pydef type Doubler <: P.Polynomial
+       __init__(self, x=10) = (self[:x] = x) 
+       my_method(self, arg1=5) = arg1 + 20  # the right-hand-side is Julia code
+       x2.get(self) = self[:x] * 2
+       x2.set!(self, new_x::Int) = (self[:x] = new_x / 2)
+    end
+
+    Doubler()[:x2]
+
+is equivalent to
+    
+    class Doubler(numpy.polynomial.Polynomial):
+       def __init__(self, x=10):
+          self.x = x
+
+       def my_method(self, arg1):
+          return arg1 + 20
+
+       @property
+       def x2(self): return self.x * 2
+
+       @x2.setter
+       def x2(self, new_val):
+           self.x = new_val / 2
+
+The methods' arguments and return values are automatically converted. All Python
+special methods are supported (__len__, __add__, etc.)
+
+`@pydef` allows for multiple-inheritance of Python types:
+
+    @pydef type SomeType <: (BaseClass1, BaseClass2)
+        ...
+    end
+
+Here's another example using [Tkinter](https://wiki.python.org/moin/TkInter)
+
+    using PyCall
+    @pyimport Tkinter as tk
+
+    @pydef type SampleApp <: tk.Tk
+	__init__(self, args...; kwargs...) = begin
+	    tk.Tk[:__init__](self, args...; kwargs...)
+	    self[:label] = tk.Label(text="Hello, world!")
+	    self[:label][:pack](padx=10, pady=10)
+	end
+    end
+
+    app = SampleApp()
+    app[:mainloop]()
+
 ### GUI Event Loops
 
 For Python packages that have a graphical user interface (GUI),

--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ The solution is fairly simple:
 
 * Python objects that you create in functions called *after* the module is loaded are always safe.
 
-* If you want to store a Python object in a global variable that is initialized automatically when the module is loaded, then initialize the variable in your module's `__init__` function.  For a type-stable global constant, initialize the constant to `PyNull()` at the top level, and then use the `copy!` function in your module's `__init__` function to mutate it to its actual value.
+* If you want to store a Python object in a global variable that is initialized automatically when the module is loaded, then initialize the variable in your module's `__init__` function.  For a type-stable global constant, initialize the constant to `PyCall.PyNULL()` at the top level, and then use the `copy!` function in your module's `__init__` function to mutate it to its actual value.
 
 For example, suppose your module uses the `scipy.optimize` module, and you want to load this module when your module is loaded and store it in a global constant `scipy_opt`.  You could do:
 
@@ -444,7 +444,7 @@ __precompile__() # this module is safe to precompile
 module MyModule
 using PyCall
 
-const scipy_opt = PyNULL()
+const scipy_opt = PyCall.PyNULL()
 
 function __init__()
     copy!(scipy_opt, pyimport("scipy.optimize"))

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ For instance,
     end
     Doubler()[:x2]
 
-is equivalent to
+is equivalent to the following Python code:
 
     import numpy.polynomial
     class Doubler(numpy.polynomial.Polynomial):

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.4
 Compat 0.7.10
 Dates
 Conda 0.1.6
+MacroTools 0.2

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.4
-Compat 0.7.9
+Compat 0.7.10
 Dates
 Conda 0.1.6

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -22,12 +22,12 @@ ENV["PYTHONIOENCODING"] = "UTF-8"
 
 #########################################################################
 
-pyconfigvar(python::AbstractString, var::AbstractString) = chomp(readall(`$python -c "import distutils.sysconfig; print(distutils.sysconfig.get_config_var('$var'))"`))
+pyconfigvar(python::AbstractString, var::AbstractString) = chomp(readstring(`$python -c "import distutils.sysconfig; print(distutils.sysconfig.get_config_var('$var'))"`))
 pyconfigvar(python, var, default) = let v = pyconfigvar(python, var)
     v == "None" ? default : v
 end
 
-pysys(python::AbstractString, var::AbstractString) = chomp(readall(`$python -c "import sys; print(sys.$var)"`))
+pysys(python::AbstractString, var::AbstractString) = chomp(readstring(`$python -c "import sys; print(sys.$var)"`))
 
 #########################################################################
 

--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -60,11 +60,14 @@ typealias PyPtr Ptr{PyObject_struct} # type for PythonObject* in ccall
 # Wrapper around Python's C PyObject* type, with hooks to Python reference
 # counting and conversion routines to/from C and Julia types.
 """
-This is a reference to a Python Object. Julia objects may be converted to Python Objects using `PyObject(juliavar)` and vice-versa using `convert(T, o::PyObject)`.
+`PyObject(juliavar)`
 
-Given o::PyObject, `o[:attribute]` is equivalent to `o.attribute` in Python, with automatic type conversion.
+This converts a julia variable to a PyObject, which is a reference to a Python object. 
+You can convert back to native julia types using `convert(T, o::PyObject)`, or using `PyAny(o)`.
 
-Given o::PyObject, `get(o, key)` is equivalent to `o[key]` in Python, with automatic type conversion.
+Given `o::PyObject`, `o[:attribute]` is equivalent to `o.attribute` in Python, with automatic type conversion.
+
+Given `o::PyObject`, `get(o, key)` is equivalent to `o[key]` in Python, with automatic type conversion.
 """
 type PyObject
     o::PyPtr # the actual PyObject*
@@ -271,9 +274,11 @@ keys(o::PyObject) = Symbol[m[1] for m in pycall(inspect["getmembers"],
 const reserved = Set{ASCIIString}(["while", "if", "for", "try", "return", "break", "continue", "function", "macro", "quote", "let", "local", "global", "const", "abstract", "typealias", "type", "bitstype", "immutable", "ccall", "do", "module", "baremodule", "using", "import", "export", "importall", "pymember", "false", "true", "Tuple"])
 
 """
-pywrap(o::PyObject) returns a wrapper `w` that is an anonymous module which provides (read) access to converted versions of o's members as w.member. 
+`pywrap(o::PyObject)`
 
-For example, `@pyimport module as name` is equivalent to `name = pywrap(pyimport("module"))`
+This returns a wrapper `w` that is an anonymous module which provides (read) access to converted versions of o's members as w.member. 
+
+For example, `@pyimport module as name` is equivalent to `const name = pywrap(pyimport("module"))`
 
 If the Python module contains identifiers that are reserved words in Julia (e.g. function), they cannot be accessed as `w.member`; one must instead use `w.pymember(:member)` (for the PyAny conversion) or w.pymember("member") (for the raw PyObject).
 """
@@ -295,12 +300,14 @@ end
 
 #########################################################################
 
+"""
+`pyimport(s::AbstractString)`
+
+Import the Python module `s` (a string or symbol) and return a pointer to it (a `PyObject`). Functions or other symbols in the module may then be looked up by s[name] where name is a string (for the raw PyObject) or symbol (for automatic type-conversion). Unlike the @pyimport macro, this does not define a Julia module and members cannot be accessed with `s.name`
+"""
 pyimport(name::AbstractString) =
     PyObject(@pycheckn ccall((@pysym :PyImport_ImportModule), PyPtr,
                              (Cstring,), name))
-"""
-Import the Python module `s` (a string or symbol) and return a pointer to it (a PyObject). Functions or other symbols in the module may then be looked up by s[name] where name is a string (for the raw PyObject) or symbol (for automatic type-conversion). Unlike the @pyimport macro, this does not define a Julia module and members cannot be accessed with `s.name`
-"""
 pyimport(name::Symbol) = pyimport(string(name))
 
 # convert expressions like :math or :(scipy.special) into module name strings
@@ -348,6 +355,8 @@ end
 
 # look up a global builtin
 """
+`pybuiltin(s::AbstractString)`
+
 Look up a string or symbol `s` among the global Python builtins. If `s` is a string it returns a PyObject, while if `s` is a symbol it returns the builtin converted to `PyAny`.
 """
 function pybuiltin(name)
@@ -359,6 +368,8 @@ end
 typealias TypeTuple{N} Union{Type,NTuple{N, Type}}
 
 """
+`pycall(o::Union{PyObject,PyPtr}, returntype::TypeTuple, args...; kwargs...)`
+
 Call the given Python function (typically looked up from a module) with the given args... (of standard Julia types which are converted automatically to the corresponding Python types if possible), converting the return value to returntype (use a returntype of PyObject to return the unconverted Python object reference, or of PyAny to request an automated conversion)
 """
 function pycall(o::Union{PyObject,PyPtr}, returntype::TypeTuple, args...; kwargs...)
@@ -560,6 +571,9 @@ function pyeval_(s::AbstractString, locals::PyDict, input_type)
 end
 
 """
+`pyeval(s::AbstractString, returntype::TypeTuple=PyAny, locals=PyDict{AbstractString, PyObject}(), 
+                                input_type=Py_eval_input; kwargs...)`
+
 This evaluates `s` as a Python string and returns the result converted to `rtype` (which defaults to `PyAny`). The remaining arguments are keywords that define local variables to be used in the expression. 
 
 For example, `pyeval("x + y", x=1, y=2)` returns 3. 

--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -60,7 +60,7 @@ typealias PyPtr Ptr{PyObject_struct} # type for PythonObject* in ccall
 # Wrapper around Python's C PyObject* type, with hooks to Python reference
 # counting and conversion routines to/from C and Julia types.
 """
-`PyObject(juliavar)`
+    PyObject(juliavar)
 
 This converts a julia variable to a PyObject, which is a reference to a Python object. 
 You can convert back to native julia types using `convert(T, o::PyObject)`, or using `PyAny(o)`.
@@ -274,7 +274,7 @@ keys(o::PyObject) = Symbol[m[1] for m in pycall(inspect["getmembers"],
 const reserved = Set{ASCIIString}(["while", "if", "for", "try", "return", "break", "continue", "function", "macro", "quote", "let", "local", "global", "const", "abstract", "typealias", "type", "bitstype", "immutable", "ccall", "do", "module", "baremodule", "using", "import", "export", "importall", "pymember", "false", "true", "Tuple"])
 
 """
-`pywrap(o::PyObject)`
+    pywrap(o::PyObject)
 
 This returns a wrapper `w` that is an anonymous module which provides (read) access to converted versions of o's members as w.member. 
 
@@ -301,7 +301,7 @@ end
 #########################################################################
 
 """
-`pyimport(s::AbstractString)`
+    pyimport(s::AbstractString)
 
 Import the Python module `s` (a string or symbol) and return a pointer to it (a `PyObject`). Functions or other symbols in the module may then be looked up by s[name] where name is a string (for the raw PyObject) or symbol (for automatic type-conversion). Unlike the @pyimport macro, this does not define a Julia module and members cannot be accessed with `s.name`
 """
@@ -355,7 +355,7 @@ end
 
 # look up a global builtin
 """
-`pybuiltin(s::AbstractString)`
+    pybuiltin(s::AbstractString)
 
 Look up a string or symbol `s` among the global Python builtins. If `s` is a string it returns a PyObject, while if `s` is a symbol it returns the builtin converted to `PyAny`.
 """
@@ -368,7 +368,7 @@ end
 typealias TypeTuple{N} Union{Type,NTuple{N, Type}}
 
 """
-`pycall(o::Union{PyObject,PyPtr}, returntype::TypeTuple, args...; kwargs...)`
+    pycall(o::Union{PyObject,PyPtr}, returntype::TypeTuple, args...; kwargs...)
 
 Call the given Python function (typically looked up from a module) with the given args... (of standard Julia types which are converted automatically to the corresponding Python types if possible), converting the return value to returntype (use a returntype of PyObject to return the unconverted Python object reference, or of PyAny to request an automated conversion)
 """
@@ -571,8 +571,8 @@ function pyeval_(s::AbstractString, locals::PyDict, input_type)
 end
 
 """
-`pyeval(s::AbstractString, returntype::TypeTuple=PyAny, locals=PyDict{AbstractString, PyObject}(), 
-                                input_type=Py_eval_input; kwargs...)`
+    pyeval(s::AbstractString, returntype::TypeTuple=PyAny, locals=PyDict{AbstractString, PyObject}(), 
+                                input_type=Py_eval_input; kwargs...)
 
 This evaluates `s` as a Python string and returns the result converted to `rtype` (which defaults to `PyAny`). The remaining arguments are keywords that define local variables to be used in the expression. 
 

--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -59,7 +59,13 @@ typealias PyPtr Ptr{PyObject_struct} # type for PythonObject* in ccall
 #########################################################################
 # Wrapper around Python's C PyObject* type, with hooks to Python reference
 # counting and conversion routines to/from C and Julia types.
+"""
+This is a reference to a Python Object. Julia objects may be converted to Python Objects using `PyObject(juliavar)` and vice-versa using `convert(T, o::PyObject)`.
 
+Given o::PyObject, `o[:attribute]` is equivalent to `o.attribute` in Python, with automatic type conversion.
+
+Given o::PyObject, `get(o, key)` is equivalent to `o[key]` in Python, with automatic type conversion.
+"""
 type PyObject
     o::PyPtr # the actual PyObject*
     function PyObject(o::PyPtr)
@@ -264,6 +270,13 @@ keys(o::PyObject) = Symbol[m[1] for m in pycall(inspect["getmembers"],
 # we skip wrapping Julia reserved words (which cannot be type members)
 const reserved = Set{ASCIIString}(["while", "if", "for", "try", "return", "break", "continue", "function", "macro", "quote", "let", "local", "global", "const", "abstract", "typealias", "type", "bitstype", "immutable", "ccall", "do", "module", "baremodule", "using", "import", "export", "importall", "pymember", "false", "true", "Tuple"])
 
+"""
+pywrap(o::PyObject) returns a wrapper `w` that is an anonymous module which provides (read) access to converted versions of o's members as w.member. 
+
+For example, `@pyimport module as name` is equivalent to `name = pywrap(pyimport("module"))`
+
+If the Python module contains identifiers that are reserved words in Julia (e.g. function), they cannot be accessed as `w.member`; one must instead use `w.pymember(:member)` (for the PyAny conversion) or w.pymember("member") (for the raw PyObject).
+"""
 function pywrap(o::PyObject, mname::Symbol=:__anon__)
     members = convert(Vector{Tuple{AbstractString,PyObject}},
                       pycall(inspect["getmembers"], PyObject, o))
@@ -285,7 +298,9 @@ end
 pyimport(name::AbstractString) =
     PyObject(@pycheckn ccall((@pysym :PyImport_ImportModule), PyPtr,
                              (Cstring,), name))
-
+"""
+Import the Python module `s` (a string or symbol) and return a pointer to it (a PyObject). Functions or other symbols in the module may then be looked up by s[name] where name is a string (for the raw PyObject) or symbol (for automatic type-conversion). Unlike the @pyimport macro, this does not define a Julia module and members cannot be accessed with `s.name`
+"""
 pyimport(name::Symbol) = pyimport(string(name))
 
 # convert expressions like :math or :(scipy.special) into module name strings
@@ -332,6 +347,9 @@ end
 #########################################################################
 
 # look up a global builtin
+"""
+Look up a string or symbol `s` among the global Python builtins. If `s` is a string it returns a PyObject, while if `s` is a symbol it returns the builtin converted to `PyAny`.
+"""
 function pybuiltin(name)
     builtin[name]
 end
@@ -340,6 +358,9 @@ end
 
 typealias TypeTuple{N} Union{Type,NTuple{N, Type}}
 
+"""
+Call the given Python function (typically looked up from a module) with the given args... (of standard Julia types which are converted automatically to the corresponding Python types if possible), converting the return value to returntype (use a returntype of PyObject to return the unconverted Python object reference, or of PyAny to request an automated conversion)
+"""
 function pycall(o::Union{PyObject,PyPtr}, returntype::TypeTuple, args...; kwargs...)
     oargs = map(PyObject, args)
     nargs = length(args)
@@ -538,6 +559,11 @@ function pyeval_(s::AbstractString, locals::PyDict, input_type)
     end
 end
 
+"""
+This evaluates `s` as a Python string and returns the result converted to `rtype` (which defaults to `PyAny`). The remaining arguments are keywords that define local variables to be used in the expression. 
+
+For example, `pyeval("x + y", x=1, y=2)` returns 3. 
+"""
 function pyeval(s::AbstractString, returntype::TypeTuple=PyAny,
                 locals=PyDict{AbstractString, PyObject}(),
                 input_type=Py_eval_input; kwargs...)

--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -7,7 +7,7 @@ export pycall, pyimport, pybuiltin, PyObject,
        pyerr_check, pyerr_clear, pytype_query, PyAny, @pyimport, PyDict,
        pyisinstance, pywrap, pytypeof, pyeval, PyVector, pystring,
        pyraise, pytype_mapping, pygui, pygui_start, pygui_stop,
-       pygui_stop_all, @pylab, set!, PyTextIO, @pysym
+       pygui_stop_all, @pylab, set!, PyTextIO, @pysym, PyNULL
 
 import Base: size, ndims, similar, copy, getindex, setindex!, stride,
        convert, pointer, summary, convert, show, haskey, keys, values,

--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -7,7 +7,7 @@ export pycall, pyimport, pybuiltin, PyObject,
        pyerr_check, pyerr_clear, pytype_query, PyAny, @pyimport, PyDict,
        pyisinstance, pywrap, pytypeof, pyeval, PyVector, pystring,
        pyraise, pytype_mapping, pygui, pygui_start, pygui_stop,
-       pygui_stop_all, @pylab, set!, PyTextIO, @pysym, PyNULL
+       pygui_stop_all, @pylab, set!, PyTextIO, @pysym, PyNULL, @pydef
 
 import Base: size, ndims, similar, copy, getindex, setindex!, stride,
        convert, pointer, summary, convert, show, haskey, keys, values,
@@ -142,6 +142,7 @@ PyObject(o::PyPtr, keep::Any) = pyembed(PyObject(o), keep)
 include("pybuffer.jl")
 include("conversions.jl")
 include("pytype.jl")
+include("pyclass.jl")
 include("callback.jl")
 include("io.jl")
 
@@ -593,14 +594,11 @@ end
 # for the reasons described in JuliaLang/julia#12256.
 
 precompile(jl_Function_call, (PyPtr,PyPtr,PyPtr))
-precompile(pyio_repr, (PyPtr,))
 precompile(pyjlwrap_dealloc, (PyPtr,))
 precompile(pyjlwrap_repr, (PyPtr,))
 precompile(pyjlwrap_hash, (PyPtr,))
 precompile(pyjlwrap_hash32, (PyPtr,))
 
-for f in (jl_IO_close, jl_IO_fileno, jl_IO_flush, jl_IO_isatty, jl_IO_readable, jl_IO_writable, jl_IO_readline, jl_IO_readlines, jl_IO_seek, jl_IO_seekable, jl_IO_tell, jl_IO_writelines, jl_IO_read_text, jl_IO_read, jl_IO_readall_text, jl_IO_readall, jl_IO_readinto, jl_IO_write)
-    precompile(f, (PyPtr,PyPtr))
-end
+# TODO: precompilation of the io.jl functions
 
 end # module PyCall

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -198,9 +198,9 @@ end
 # PyVector: no-copy wrapping of a Julia object around a Python sequence
 
 """
-This is a wrapper around an arbitrary Python list or sequence object. 
+`PyVector(o::PyObject)`
 
-`PyVector(o::PyObject)` returns a PyVector object. 
+This returns a PyVector object, which is a wrapper around an arbitrary Python list or sequence object. 
 
 Alternatively, `PyVector` can be used as the return type for a `pycall` that returns a sequence object (including tuples).
 """
@@ -388,9 +388,10 @@ include("numpy.jl")
 # PyDict: no-copy wrapping of a Julia object around a Python dictionary
 
 """
-This is a no-copy wrapper around a Python dictionary.
+`PyDict(o::PyObject)`
+`PyDict(d::Dict{K,V})`
 
-`PyDict(o::PyObject)` or `PyDict(d::Dict{K,V})` both return a PyDict.
+This returns a PyDict, which is a no-copy wrapper around a Python dictionary.
 
 Alternatively, you can specify the return type of a `pycall` as PyDict. 
 """

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -197,6 +197,13 @@ end
 #########################################################################
 # PyVector: no-copy wrapping of a Julia object around a Python sequence
 
+"""
+This is a wrapper around an arbitrary Python list or sequence object. 
+
+`PyVector(o::PyObject)` returns a PyVector object. 
+
+Alternatively, `PyVector` can be used as the return type for a `pycall` that returns a sequence object (including tuples).
+"""
 type PyVector{T} <: AbstractVector{T}
     o::PyObject
     function PyVector(o::PyObject)
@@ -380,6 +387,13 @@ include("numpy.jl")
 #########################################################################
 # PyDict: no-copy wrapping of a Julia object around a Python dictionary
 
+"""
+This is a no-copy wrapper around a Python dictionary.
+
+`PyDict(o::PyObject)` or `PyDict(d::Dict{K,V})` both return a PyDict.
+
+Alternatively, you can specify the return type of a `pycall` as PyDict. 
+"""
 type PyDict{K,V} <: Associative{K,V}
     o::PyObject
     isdict::Bool # whether this is a Python Dict (vs. generic Mapping object)

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -198,7 +198,7 @@ end
 # PyVector: no-copy wrapping of a Julia object around a Python sequence
 
 """
-`PyVector(o::PyObject)`
+    PyVector(o::PyObject)
 
 This returns a PyVector object, which is a wrapper around an arbitrary Python list or sequence object. 
 
@@ -388,8 +388,8 @@ include("numpy.jl")
 # PyDict: no-copy wrapping of a Julia object around a Python dictionary
 
 """
-`PyDict(o::PyObject)`
-`PyDict(d::Dict{K,V})`
+    PyDict(o::PyObject)
+    PyDict(d::Dict{K,V})
 
 This returns a PyDict, which is a no-copy wrapper around a Python dictionary.
 

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -604,7 +604,7 @@ function mpmath_init()
         copy!(mpf, mpmath["mpf"])
         copy!(mpc, mpmath["mpc"])
     end
-    curprec = get_bigfloat_precision()
+    curprec = precision(BigFloat)
     if mpprec[1] != curprec
         mpprec[1] = curprec
         mpmath["mp"]["prec"] = mpprec[1]

--- a/src/gui.jl
+++ b/src/gui.jl
@@ -30,7 +30,7 @@ pygui_works(gui::Symbol) = gui == :default ||
 
 # get or set the default GUI; doesn't affect running GUI
 """
-`pygui()`
+    pygui()
 
 Return the current GUI toolkit as a symbol. 
 """
@@ -152,7 +152,7 @@ end
 const eventloops = Dict{Symbol,Timer}()
 
 """
-`pygui_start(gui::Symbol = pygui())` 
+    pygui_start(gui::Symbol = pygui())
 
 Start the event loop of a certain toolkit. 
 
@@ -188,7 +188,7 @@ function pygui_start(gui::Symbol=pygui(), sec::Real=50e-3)
 end
 
 """
-`pygui_stop(gui::Symbol = pygui())`
+    pygui_stop(gui::Symbol = pygui())
 
 Stop any running event loop for gui. The `gui` argument defaults to current default GUI. 
 

--- a/src/gui.jl
+++ b/src/gui.jl
@@ -30,6 +30,8 @@ pygui_works(gui::Symbol) = gui == :default ||
 
 # get or set the default GUI; doesn't affect running GUI
 """
+`pygui()`
+
 Return the current GUI toolkit as a symbol. 
 """
 function pygui()
@@ -150,7 +152,9 @@ end
 const eventloops = Dict{Symbol,Timer}()
 
 """
-Use `pygui_start(gui)` to start the event loop of a certain toolkit. 
+`pygui_start(gui::Symbol = pygui())` 
+
+Start the event loop of a certain toolkit. 
 
 The argument `gui` defaults to the current default GUI, but it could be `:wx`, `:gtk`, `:gtk3`, `:tk`, or `:qt`. 
 
@@ -184,6 +188,8 @@ function pygui_start(gui::Symbol=pygui(), sec::Real=50e-3)
 end
 
 """
+`pygui_stop(gui::Symbol = pygui())`
+
 Stop any running event loop for gui. The `gui` argument defaults to current default GUI. 
 
 """

--- a/src/gui.jl
+++ b/src/gui.jl
@@ -29,6 +29,9 @@ pygui_works(gui::Symbol) = gui == :default ||
      (gui == :qt && (pyexists("PyQt4") || pyexists("PySide"))))
 
 # get or set the default GUI; doesn't affect running GUI
+"""
+Return the current GUI toolkit as a symbol. 
+"""
 function pygui()
     global gui
     if gui::Symbol != :default && pygui_works(gui::Symbol)
@@ -146,6 +149,12 @@ end
 # cache running event loops (so that we don't start any more than once)
 const eventloops = Dict{Symbol,Timer}()
 
+"""
+Use `pygui_start(gui)` to start the event loop of a certain toolkit. 
+
+The argument `gui` defaults to the current default GUI, but it could be `:wx`, `:gtk`, `:gtk3`, `:tk`, or `:qt`. 
+
+"""
 function pygui_start(gui::Symbol=pygui(), sec::Real=50e-3)
     pygui(gui)
     if !haskey(eventloops, gui)
@@ -174,6 +183,10 @@ function pygui_start(gui::Symbol=pygui(), sec::Real=50e-3)
     gui
 end
 
+"""
+Stop any running event loop for gui. The `gui` argument defaults to current default GUI. 
+
+"""
 function pygui_stop(gui::Symbol=pygui())
     if haskey(eventloops, gui)
         Base.close(pop!(eventloops, gui))

--- a/src/gui.jl
+++ b/src/gui.jl
@@ -74,16 +74,20 @@ macro doevent(body)
     Expr(:function, :($(esc(:doevent))(async)), body)
 end
 
-# GTK (either GTK2 or GTK3, depending on gtkmodule):
-function gtk_eventloop(gtkmodule::AbstractString, sec::Real=50e-3)
+# For PyPlot issue #181: recent pygobject releases emit a warning
+# if we don't specify which version we want:
+function gtk_requireversion(gtkmodule::AbstractString, vers::VersionNumber=v"3.0")
     if startswith(gtkmodule, "gi.")
-        # issue #181: recent pygobject releases emit a warning
-        # if we don't specify which version we want:
         gi = pyimport("gi")
         if gi[:get_required_version]("Gtk") === nothing
-            gi[:require_version]("Gtk", "3.0")
+            gi[:require_version]("Gtk", string(vers))
         end
     end
+end
+
+# GTK (either GTK2 or GTK3, depending on gtkmodule):
+function gtk_eventloop(gtkmodule::AbstractString, sec::Real=50e-3)
+    gtk_requireversion(gtkmodule)
     gtk = pyimport(gtkmodule)
     events_pending = gtk["events_pending"]
     main_iteration = gtk["main_iteration"]

--- a/src/io.jl
+++ b/src/io.jl
@@ -365,6 +365,12 @@ function PyObject(io::IO)
     pyjlwrap_new(jl_IOType, io)
 end
 
+"""
+Julia IO streams are converted into Python objects implementing the RawIOBase interface, 
+so they can be used for binary I/O in Python
+
+Call `PyTextIO(io::IO)` or `PyObject(io::IO)` to return a PyTextIO object.
+"""
 function PyTextIO(io::IO)
     pyio_initialize()
     pyjlwrap_new(jl_TextIOType, io)

--- a/src/io.jl
+++ b/src/io.jl
@@ -366,8 +366,8 @@ function PyObject(io::IO)
 end
 
 """
-`PyTextIO(io::IO)`
-`PyObject(io::IO)`
+    PyTextIO(io::IO)
+    PyObject(io::IO)
 
 Julia IO streams are converted into Python objects implementing the RawIOBase interface, 
 so they can be used for binary I/O in Python

--- a/src/io.jl
+++ b/src/io.jl
@@ -366,10 +366,11 @@ function PyObject(io::IO)
 end
 
 """
+`PyTextIO(io::IO)`
+`PyObject(io::IO)`
+
 Julia IO streams are converted into Python objects implementing the RawIOBase interface, 
 so they can be used for binary I/O in Python
-
-Call `PyTextIO(io::IO)` or `PyObject(io::IO)` to return a PyTextIO object.
 """
 function PyTextIO(io::IO)
     pyio_initialize()

--- a/src/numpy.jl
+++ b/src/numpy.jl
@@ -262,6 +262,13 @@ c_contiguous(i::PyArray_Info) = f_contiguous(i.T, flipdim(i.sz,1), flipdim(i.st,
 # functions, but that is not possible at the moment.  So, to use this
 # with Julia linalg functions etcetera a copy is still required.
 
+"""
+This implements a nocopy wrapper to a NumPy array (currently of only numeric types only). 
+
+Convert a PyObject to PyArray by calling `PyArray(o::PyObject)` on an `ndarray` object `o`.
+
+If you are using `pycall` and the function returns an `ndarray`, you can use `PyArray` as the return type to directly receive a `PyArray`. 
+"""
 type PyArray{T,N} <: AbstractArray{T,N}
     o::PyObject
     info::PyArray_Info

--- a/src/numpy.jl
+++ b/src/numpy.jl
@@ -263,9 +263,11 @@ c_contiguous(i::PyArray_Info) = f_contiguous(i.T, flipdim(i.sz,1), flipdim(i.st,
 # with Julia linalg functions etcetera a copy is still required.
 
 """
-This implements a nocopy wrapper to a NumPy array (currently of only numeric types only). 
+PyArray(o::PyObject)
 
-Convert a PyObject to PyArray by calling `PyArray(o::PyObject)` on an `ndarray` object `o`.
+This converts an `ndarray` object `o` to a PyArray.
+
+This implements a nocopy wrapper to a NumPy array (currently of only numeric types only). 
 
 If you are using `pycall` and the function returns an `ndarray`, you can use `PyArray` as the return type to directly receive a `PyArray`. 
 """

--- a/src/numpy.jl
+++ b/src/numpy.jl
@@ -263,7 +263,7 @@ c_contiguous(i::PyArray_Info) = f_contiguous(i.T, flipdim(i.sz,1), flipdim(i.st,
 # with Julia linalg functions etcetera a copy is still required.
 
 """
-PyArray(o::PyObject)
+    PyArray(o::PyObject)
 
 This converts an `ndarray` object `o` to a PyArray.
 

--- a/src/pyclass.jl
+++ b/src/pyclass.jl
@@ -1,0 +1,197 @@
+# Define Python classes out of Julia types
+
+using MacroTools: @capture
+
+######################################################################
+# def_py_class definition: this is the core non-macro interface for creating
+# a Python class from a Julia type.
+
+"""
+    def_py_class(type_name::AbstractString, methods::Vector;
+                 base_classes=[], getsets::Vector=[])
+
+`def_py_class` creates a Python class whose methods are implemented in Julia.
+`@pydef` macros expand into a call to this function.
+
+Arguments
+---------
+- `methods`: a vector of tuples `(py_name::String, jl_fun::Function)`
+   py_name will be a method of the Python class, which will call `jl_function`
+- `base_classes`: the Python base classes to inherit from.
+
+Return value: the created class (::PyTypeObject)
+"""
+function def_py_class(type_name::AbstractString, methods::Vector;
+                      base_classes=[], getsets::Vector=[])
+    # Only create new-style classes
+    base_classes = union(base_classes, [pybuiltin("object")])
+    new_type = pybuiltin("type")(type_name, tuple(base_classes...), Dict())
+    for (py_name, jl_fun) in methods
+        new_type[py_name::Symbol] = jlfun2pyfun(jl_fun::Function)
+    end
+    for (py_name, getter, setter) in getsets
+        new_type[py_name::Symbol] = pyproperty(jlfun2pyfun(getter),
+                                               jlfun2pyfun(setter))
+    end
+    new_type
+end
+        
+
+######################################################################
+# @pydef macro
+
+# Helper for `parse_pydef`
+# Returns (class_name::Symbol, base_classes, lines)
+# where there's one `line` per method definition
+function parse_pydef_toplevel(expr)
+    if @capture(expr, begin type class_name_ <: base_classes_expr_
+                    lines__
+                end end)
+        if !@capture(base_classes_expr, (base_classes__,))
+            base_classes = (base_classes_expr,)
+        end
+    else
+        @assert(@capture(expr, type class_name_
+                    lines__
+            end), "Malformed @pydef expression")
+        
+        base_classes = []
+    end
+    if isa(lines[1], Expr) && lines[1].head == :block 
+        # unfortunately, @capture fails to parse the type's fields correctly
+        # It's been reported and fixed, we can remove this line on the next
+        # MacroTools release (> v0.2)
+        lines = lines[1].args
+    end
+    return class_name::Symbol, base_classes, lines
+end
+    
+
+function parse_pydef(expr)
+    class_name, base_classes, lines = parse_pydef_toplevel(expr)
+    # Now we parse every method definition / getter / setter
+    function_defs = Expr[] # vector of :(function ...) expressions
+    methods = Tuple{Any, Symbol}[] # (py_name, jl_method_name)
+    getter_dict = Dict{Any, Symbol}() # python_var => jl_getter_name
+    setter_dict = Dict{Any, Symbol}() 
+    method_syms = Dict{Any, Symbol}() # see below
+    for line in lines
+        if !isa(line, LineNumberNode) && line.head != :line # need to skip those
+            @assert line.head == :(=) "Malformed line: $line"
+            lhs, rhs = line.args
+            @assert @capture(lhs,py_f_(args__)) "Malformed left-hand-side: $lhs"
+            if isa(py_f, Symbol)
+                # Method definition
+                # We save the gensym to support multiple dispatch
+                #    readlines(io) = ...
+                #    readlines(io, nlines) = ...
+                # otherwise the first and second `readlines` get different
+                # gensyms, and one of the two gets shadowed by the other.
+                jl_fun_name = get!(method_syms, py_f, gensym(py_f))
+                if py_f == :__init__
+                    # __init__ must return `nothing` in Python. This is
+                    # achieved by default in Python, but not so in Julia, so we
+                    # special-case it for convenience.
+                    rhs = :(begin $rhs; nothing end)
+                end
+                push!(function_defs, :(function $jl_fun_name($(args...))
+                    $rhs
+                end))
+                push!(methods, (py_f, jl_fun_name))
+            elseif @capture(py_f, attribute_.access_)
+                # Accessor (.get/.set) definition
+                if access == :get
+                    dict = getter_dict
+                elseif access == :set!
+                    dict = setter_dict
+                else
+                    error("$access is not a valid accessor; must be either get or set!")
+                end
+                jl_fun_name = gensym(symbol(attribute,:_,access))
+                push!(function_defs, :(function $jl_fun_name($(args...))
+                    $rhs
+                end))
+                dict[attribute] = jl_fun_name
+            else
+                error("Malformed line: $line")
+            end
+        end
+    end
+    @assert(isempty(setdiff(keys(setter_dict), keys(getter_dict))),
+            "All .set attributes must have a .get")
+    class_name, base_classes, methods, getter_dict, setter_dict, function_defs
+end
+
+
+
+""" `@pydef` creates a Python class whose methods are implemented in Julia.
+Example: <br><br>
+    
+    @pyimport numpy.polynomial as P
+
+    @pydef type Doubler <: P.Polynomial
+       __init__(self, x=10) = (self[:x] = x) 
+       my_method(self, arg1=5) = arg1 + 20  # the right-hand-side is Julia code
+       x2.get(self) = self[:x] * 2
+       x2.set!(self, new_x::Int) = (self[:x] = new_x / 2)
+    end
+
+    Doubler()[:x2]
+
+is equivalent to <br><br>
+    
+    class JuliaType(numpy.polynomial.Polynomial):
+       def __init__(self, x=10):
+          self.x = x
+
+       def my_method(self, arg1):
+          return arg1 + 20
+
+       @property
+       def x2(self): return self.x * 2
+
+       @x2.setter
+       def x2(self, new_val):
+           self.x = new_val / 2
+
+The methods' arguments and return values are automatically converted. All Python
+special methods are supported (__len__, __add__, etc.)
+
+`@pydef` allows for multiple-inheritance of Python types:
+
+    @pydef type SomeType <: (BaseClass1, BaseClass2)
+        ...
+    end
+
+Multiple dispatch works, too:
+
+    x2.set!(self, new_x::Int) = ...
+    x2.set!(self, new_x::Float64) = ...
+"""
+macro pydef(class_expr)
+    class_name, _, _ = parse_pydef_toplevel(class_expr)
+    :(const $(esc(class_name)) = @pydef_object($(esc(class_expr))))
+end
+
+
+""" `@pydef_object` is like `@pydef`, but it returns the
+metaclass as a `PyObject` instead of binding it to the class name.
+It's side-effect-free, except for the definition of the class methods. """
+macro pydef_object(class_expr)
+    class_name, base_classes, methods_, getter_dict, setter_dict, function_defs=
+        parse_pydef(class_expr)
+    methods = [:($(Expr(:quote, py_name::Symbol)), $(esc(jl_fun::Symbol)))
+               for (py_name, jl_fun) in methods_]
+    getsets = [:($(Expr(:quote, attribute)),
+                 $(esc(getter)),
+                 $(esc(get(setter_dict, attribute, nothing))))
+               for (attribute, getter) in getter_dict]
+    :(begin
+        $(map(esc, function_defs)...)
+        # This line doesn't have any side-effect, it just returns the Python
+        # (meta-)class, as a PyObject
+        def_py_class($(string(class_name)), [$(methods...)];
+                     base_classes=[$(map(esc, base_classes)...)],
+                     getsets=[$(getsets...)])
+    end)
+end

--- a/src/pyclass.jl
+++ b/src/pyclass.jl
@@ -127,19 +127,18 @@ For instance,
     @pyimport numpy.polynomial as P
     @pydef type Doubler <: P.Polynomial
         __init__(self, x=10) = (self[:x] = x)
-        my_method(self, arg1=5) = arg1 + 20  # the right-hand-side is Julia code
+        my_method(self, arg1::Number) = arg1 + 20
         x2.get(self) = self[:x] * 2
-        x2.set!(self, new_x::Int) = (self[:x] = new_x / 2)
+        x2.set!(self, new_val) = (self[:x] = new_val / 2)
     end
     Doubler()[:x2]
 
-is equivalent to the following Python code:
+is essentially equivalent to the following Python code:
 
     class JuliaType(numpy.polynomial.Polynomial):
         def __init__(self, x=10):
             self.x = x
-        def my_method(self, arg1):
-            return arg1 + 20
+        def my_method(self, arg1): return arg1 + 20
         @property
         def x2(self): return self.x * 2
         @x2.setter
@@ -147,7 +146,7 @@ is equivalent to the following Python code:
             self.x = new_val / 2
     Doubler().x2
 
-The method arguments and return values are automatically converted. All Python
+The method arguments and return values are automatically converted between Julia and Python. All Python
 special methods are supported (`__len__`, `__add__`, etc.)
 
 `@pydef` allows for multiple inheritance of Python types:

--- a/src/pyclass.jl
+++ b/src/pyclass.jl
@@ -1,4 +1,4 @@
-# Define Python classes out of Julia types
+# Define new Python classes from Julia:
 
 using MacroTools: @capture
 
@@ -35,7 +35,6 @@ function def_py_class(type_name::AbstractString, methods::Vector;
     end
     new_type
 end
-        
 
 ######################################################################
 # @pydef macro
@@ -54,10 +53,10 @@ function parse_pydef_toplevel(expr)
         @assert(@capture(expr, type class_name_
                     lines__
             end), "Malformed @pydef expression")
-        
+
         base_classes = []
     end
-    if isa(lines[1], Expr) && lines[1].head == :block 
+    if isa(lines[1], Expr) && lines[1].head == :block
         # unfortunately, @capture fails to parse the type's fields correctly
         # It's been reported and fixed, we can remove this line on the next
         # MacroTools release (> v0.2)
@@ -65,7 +64,6 @@ function parse_pydef_toplevel(expr)
     end
     return class_name::Symbol, base_classes, lines
 end
-    
 
 function parse_pydef(expr)
     class_name, base_classes, lines = parse_pydef_toplevel(expr)
@@ -73,7 +71,7 @@ function parse_pydef(expr)
     function_defs = Expr[] # vector of :(function ...) expressions
     methods = Tuple{Any, Symbol}[] # (py_name, jl_method_name)
     getter_dict = Dict{Any, Symbol}() # python_var => jl_getter_name
-    setter_dict = Dict{Any, Symbol}() 
+    setter_dict = Dict{Any, Symbol}()
     method_syms = Dict{Any, Symbol}() # see below
     for line in lines
         if !isa(line, LineNumberNode) && line.head != :line # need to skip those
@@ -122,15 +120,13 @@ function parse_pydef(expr)
     class_name, base_classes, methods, getter_dict, setter_dict, function_defs
 end
 
-
-
 """ `@pydef` creates a Python class whose methods are implemented in Julia.
 Example: <br><br>
-    
+
     @pyimport numpy.polynomial as P
 
     @pydef type Doubler <: P.Polynomial
-       __init__(self, x=10) = (self[:x] = x) 
+       __init__(self, x=10) = (self[:x] = x)
        my_method(self, arg1=5) = arg1 + 20  # the right-hand-side is Julia code
        x2.get(self) = self[:x] * 2
        x2.set!(self, new_x::Int) = (self[:x] = new_x / 2)
@@ -139,7 +135,7 @@ Example: <br><br>
     Doubler()[:x2]
 
 is equivalent to <br><br>
-    
+
     class JuliaType(numpy.polynomial.Polynomial):
        def __init__(self, x=10):
           self.x = x
@@ -172,7 +168,6 @@ macro pydef(class_expr)
     class_name, _, _ = parse_pydef_toplevel(class_expr)
     :(const $(esc(class_name)) = @pydef_object($(esc(class_expr))))
 end
-
 
 """ `@pydef_object` is like `@pydef`, but it returns the
 metaclass as a `PyObject` instead of binding it to the class name.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -134,7 +134,7 @@ pyutf8(s::PyObject) = pycall(s["encode"], PyObject, "utf-8")
 pyutf8(s::ByteString) = pyutf8(PyObject(s))
 
 # IO (issue #107)
-@test roundtripeq(STDOUT)
+#@test roundtripeq(STDOUT) # No longer true since #250
 let buf = IOBuffer(false, true), obuf = PyObject(buf)
     @test !obuf[:isatty]()
     @test obuf[:writable]()
@@ -171,7 +171,7 @@ let buf = IOBuffer("hello\nagain"), obuf = PyTextIO(buf)
 end
 let nm = tempname()
     open(nm, "w") do f
-        @test roundtripeq(f)
+        # @test roundtripeq(f)  # PR #250
         pf = PyObject(f)
         @test pf[:fileno]() == fd(f)
         @test pf[:writable]()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -259,3 +259,8 @@ end
 
 # issue #216:
 @test length(collect(pyimport("itertools")[:combinations]([1,2,3],2))) == 3
+
+# PyNULL and copy!
+let x = PyNULL(), y = copy!(x, PyObject(314159))
+    @test Int(x) == Int(y) == 314159
+end


### PR DESCRIPTION
My SymPy.jl failed to build with this warning:

```
julia> using SymPy
WARNING: get_bigfloat_precision() is deprecated, use precision(BigFloat) instead.
 [inlined code] from ./error.jl:26
 in depwarn(::ASCIIString, ::Symbol) at ./deprecated.jl:64
 in get_bigfloat_precision() at ./deprecated.jl:50
 in mpmath_init() at /home/roger/.julia/v0.5/PyCall/src/conversions.jl:610
 in init_mpmath() at /home/roger/.julia/v0.5/SymPy/src/mpmath.jl:43
 in __init__() at /home/roger/.julia/v0.5/SymPy/src/SymPy.jl:315
 in _require_from_serialized(::Int64, ::Symbol, ::ASCIIString, ::Bool) at ./loading.jl:165
 in _require_from_serialized(::Int64, ::Symbol, ::Bool) at ./loading.jl:193
 in require(::Symbol) at ./loading.jl:323
 in eval(::Module, ::Any) at ./boot.jl:237
while loading no file, in expression starting on line 0
```

After correct this line, it somehow works just fine.