### PR TITLE
Fix depwarn on 0.5

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.4
-Compat 0.7.14
+Compat 0.7.15
 Conda 0.1.6
 MacroTools 0.2

--- a/src/numpy.jl
+++ b/src/numpy.jl
@@ -85,7 +85,7 @@ function npyinitialize()
     end
     API = pointer_to_array(PyArray_API, (PyArray_API_length,))
     for m in eachmatch(r, hdr) # build npy_api table
-        npy_api[symbol(m.captures[1])] = API[parse(Int, m.captures[2])+1]
+        npy_api[Symbol(m.captures[1])] = API[parse(Int, m.captures[2])+1]
     end
     if !haskey(npy_api, :PyArray_New)
         error("failure parsing NumPy PyArray_API symbol table")

--- a/src/pyclass.jl
+++ b/src/pyclass.jl
@@ -105,7 +105,7 @@ function parse_pydef(expr)
                 else
                     error("$access is not a valid accessor; must be either get or set!")
                 end
-                jl_fun_name = gensym(symbol(attribute,:_,access))
+                jl_fun_name = gensym(Symbol(attribute,:_,access))
                 push!(function_defs, :(function $jl_fun_name($(args...))
                     $rhs
                 end))

--- a/src/pydates.jl
+++ b/src/pydates.jl
@@ -98,8 +98,8 @@ function PyObject(p::Dates.Millisecond)
 end
 
 for T in (:Date, :DateTime, :Delta)
-    f = symbol(string("Py", T, "_Check"))
-    t = Expr(:., :PyDateTimeAPI, QuoteNode(symbol(string(T, "Type"))))
+    f = Symbol(string("Py", T, "_Check"))
+    t = Expr(:., :PyDateTimeAPI, QuoteNode(Symbol(string(T, "Type"))))
     @eval $f(o::PyObject) = pyisinstance(o, $t)
 end
 

--- a/src/pytype.jl
+++ b/src/pytype.jl
@@ -261,7 +261,7 @@ type PyTypeObject
     # Julia-specific fields, after the end of the Python structure:
 
     # save the tp_name Julia string so that it is not garbage-collected
-    tp_name_save::ASCIIString
+    tp_name_save # This is a gc slot that is never read from
 
     function PyTypeObject(name::AbstractString, basicsize::Integer, init::Function)
         # figure out Py_TPFLAGS_DEFAULT, depending on Python version
@@ -280,7 +280,8 @@ type PyTypeObject
              Py_TPFLAGS_HAVE_CLASS |
              Py_TPFLAGS_HAVE_STACKLESS_EXTENSION |
              Py_TPFLAGS_HAVE_INDEX)
-        name_save = bytestring(name)
+        # This and the `unsafe_convert` below emulate a `ccall`
+        name_save = Base.cconvert(Ptr{UInt8}, name)
         t = new(0,C_NULL,0,
                 unsafe_convert(Ptr{UInt8}, name_save),
                 convert(Int, basicsize), 0,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using Base.Test, PyCall, Compat
+import Compat.String
 
 PYTHONPATH=get(ENV,"PYTHONPATH","")
 PYTHONHOME=get(ENV,"PYTHONHOME","")
@@ -132,7 +133,7 @@ end
 # in Python 3, we need a specific encoding to write strings or bufferize them
 # (http://stackoverflow.com/questions/5471158/typeerror-str-does-not-support-the-buffer-interface)
 pyutf8(s::PyObject) = pycall(s["encode"], PyObject, "utf-8")
-pyutf8(s::ByteString) = pyutf8(PyObject(s))
+pyutf8(s::String) = pyutf8(PyObject(s))
 
 # IO (issue #107)
 #@test roundtripeq(STDOUT) # No longer true since #250


### PR DESCRIPTION
`String`, `Symbol`, `precision(BigFloat)`
Also fix an incorrect use of `unsafe_convert`.

Requires a new tag of `Compat`.
Also includes https://github.com/stevengj/PyCall.jl/pull/260

Requires https://github.com/JuliaLang/Compat.jl/pull/192
