### PR TITLE
Fix #271

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -82,7 +82,14 @@ function pyio_initialize()
             closed.get(self) = @with_ioraise(!isopen(pyio_jl(self)))
             encoding.get(self) = "UTF-8"
             fileno(self) = @with_ioraise(fd(pyio_jl(self)))
-            flush(self) = @with_ioraise(flush(pyio_jl(self)))
+            flush(self) = begin
+                @with_ioraise begin
+                    io = pyio_jl(self)
+                    if method_exists(flush, Tuple{typeof(io)})
+                        flush(io)
+                    end
+                end
+            end
             isatty(self) = isa(pyio_jl(self), Base.TTY)
             readable(self) = isreadable(pyio_jl(self))
             writable(self) = iswritable(pyio_jl(self))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -143,6 +143,7 @@ let buf = IOBuffer(false, true), obuf = PyObject(buf)
     @test !obuf[:readable]()
     @test obuf[:seekable]()
     obuf[:write](pyutf8("hello"))
+    obuf[:flush]()  # should be a no-op, since there's no flushing IOBuffer
     @test position(buf) == obuf[:tell]() == 5
     let p = obuf[:seek](-2, 1)
         @test p == position(buf) == 3


### PR DESCRIPTION
When I translated the IO code to `@pydef`, I neglected to bring in that check from the `jl_io_flush` function.