### PR TITLE
Fix incorrect ccall argument type

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -708,7 +708,7 @@ pynothing_query(o::PyObject) = o.o == pynothing[] ? Void : Union{}
 # we check for "items" attr since PyMapping_Check doesn't do this (it only
 # checks for __getitem__) and PyMapping_Check returns true for some
 # scipy scalar array members, grrr.
-pydict_query(o::PyObject) = pyisinstance(o, @pyglobalobj :PyDict_Type) || (pyquery((@pyglobal :PyMapping_Check), o) && ccall((@pysym :PyObject_HasAttrString), Cint, (PyPtr,Array{UInt8}), o, "items") == 1) ? Dict{PyAny,PyAny} : Union{}
+pydict_query(o::PyObject) = pyisinstance(o, @pyglobalobj :PyDict_Type) || (pyquery((@pyglobal :PyMapping_Check), o) && ccall((@pysym :PyObject_HasAttrString), Cint, (PyPtr,Ptr{UInt8}), o, "items") == 1) ? Dict{PyAny,PyAny} : Union{}
 
 typetuple(Ts) = Tuple{Ts...}
 


### PR DESCRIPTION
`Array` as argument type means passing the array by reference, not passing the pointer to a string. This is what's causing https://github.com/JuliaLang/julia/issues/15432 and https://github.com/stevengj/PyCall.jl/issues/254#issuecomment-206515726 (plus incorrect handling in the ABI).