### PR TITLE
Add LegacyStrings for julia 0.5 compatability

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.4
 Compat 0.8.0
 Conda 0.2
 MacroTools 0.2
+LegacyStrings

--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -30,6 +30,7 @@ import Compat.String
 @compat import Base.show
 import Base.unsafe_convert
 import MacroTools   # because of issue #270
+using LegacyStrings
 
 #########################################################################
 


### PR DESCRIPTION
This should make things run on current julia 0.5 builds.