### PR TITLE
Fix julia 0.5 deprecation warnings

### DIFF
--- a/src/gui.jl
+++ b/src/gui.jl
@@ -41,7 +41,7 @@ function pygui()
     else
         for g in (:tk, :qt, :wx, :gtk, :gtk3)
             if pygui_works(g)
-                gui::Symbol = g
+                gui = g
                 return gui::Symbol
             end
         end
@@ -56,9 +56,9 @@ function pygui(g::Symbol)
         elseif !pygui_works(g)
             error("Python GUI toolkit for $g is not installed.")
         end
-        gui::Symbol = g
+        gui = g
     end
-    return g
+    return g::Symbol
 end
 
 ############################################################################

--- a/src/io.jl
+++ b/src/io.jl
@@ -113,7 +113,7 @@ function pyio_initialize()
             readinto(self, b) = @with_ioraise(readbytes!(pyio_jl(self), b))
             write(self, b) = @with_ioraise(write(pyio_jl(self), b))
         end)
-        pyio_initialized::Bool = true
+        pyio_initialized = true
     end
     return
 end

--- a/src/numpy.jl
+++ b/src/numpy.jl
@@ -91,7 +91,7 @@ function npyinitialize()
         error("failure parsing NumPy PyArray_API symbol table")
     end
 
-    npy_initialized::Bool = true
+    npy_initialized = true
     return
 end
 


### PR DESCRIPTION
Would be great to tag another version once this is merged.

This fixes deprecation warnings that show up during precompile.