### PR TITLE
Initialize global pointers to NULL explicitly

### DIFF
--- a/src/pydates.jl
+++ b/src/pydates.jl
@@ -48,12 +48,12 @@ end
 const PyDate_HEAD = sizeof(Int)+sizeof(PyPtr)+sizeof(Py_hash_t)+1
 
 # called from __init__
-const DateType = Ref{PyPtr}()
-const DateTimeType = Ref{PyPtr}()
-const DeltaType = Ref{PyPtr}()
-const Date_FromDate = Ref{Ptr{Void}}()
-const DateTime_FromDateAndTime = Ref{Ptr{Void}}()
-const Delta_FromDelta = Ref{Ptr{Void}}()
+const DateType = Ref{PyPtr}(0)
+const DateTimeType = Ref{PyPtr}(0)
+const DeltaType = Ref{PyPtr}(0)
+const Date_FromDate = Ref{Ptr{Void}}(0)
+const DateTime_FromDateAndTime = Ref{Ptr{Void}}(0)
+const Delta_FromDelta = Ref{Ptr{Void}}(0)
 function init_datetime()
     # emulate PyDateTime_IMPORT:
     PyDateTimeAPI = unsafe_load(@pycheckn ccall((@pysym :PyCapsule_Import),

--- a/src/pyinit.jl
+++ b/src/pyinit.jl
@@ -19,8 +19,8 @@ const c_void_p_Type = PyNULL()
 
 # other global constants initialized at runtime are defined via Ref
 # or are simply left as non-const values
-const pynothing = Ref{PyPtr}()
-const pyxrange = Ref{PyPtr}()
+const pynothing = Ref{PyPtr}(0)
+const pyxrange = Ref{PyPtr}(0)
 
 #########################################################################
 


### PR DESCRIPTION
Fix SegFault with precompilation off.

Noticed this since I was testing packages with precompilation disabled due to https://github.com/JuliaLang/julia/issues/17809
