### PR TITLE
Test on 3.5

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,12 +7,12 @@ environment:
     PYTHON: "C:\\Python27\\python.exe"
 
   - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-    PYTHONDIR: "C:\\Python33"
-    PYTHON: "C:\\Python33\\python.exe"
-
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
     PYTHONDIR: "C:\\Python34"
     PYTHON: "C:\\Python34\\python.exe"
+
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
+    PYTHONDIR: "C:\\Python35"
+    PYTHON: "C:\\Python35\\python.exe"
 
   - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
     PYTHONDIR: "use_conda"
@@ -23,12 +23,12 @@ environment:
     PYTHON: "C:\\Python27-x64\\python.exe"
 
   - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
-    PYTHONDIR: "C:\\Python33-x64"
-    PYTHON: "C:\\Python33-x64\\python.exe"
-
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
     PYTHONDIR: "C:\\Python34-x64"
     PYTHON: "C:\\Python34-x64\\python.exe"
+
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
+    PYTHONDIR: "C:\\Python35-x64"
+    PYTHON: "C:\\Python35-x64\\python.exe"
 
   - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
     PYTHONDIR: "use_conda"
@@ -40,12 +40,12 @@ environment:
     PYTHON: "C:\\Python27\\python.exe"
 
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
-    PYTHONDIR: "C:\\Python33"
-    PYTHON: "C:\\Python33\\python.exe"
-
-  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
     PYTHONDIR: "C:\\Python34"
     PYTHON: "C:\\Python34\\python.exe"
+
+  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
+    PYTHONDIR: "C:\\Python35"
+    PYTHON: "C:\\Python35\\python.exe"
 
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
     PYTHONDIR: "use_conda"
@@ -56,12 +56,12 @@ environment:
     PYTHON: "C:\\Python27-x64\\python.exe"
 
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
-    PYTHONDIR: "C:\\Python33-x64"
-    PYTHON: "C:\\Python33-x64\\python.exe"
-
-  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
     PYTHONDIR: "C:\\Python34-x64"
     PYTHON: "C:\\Python34-x64\\python.exe"
+
+  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+    PYTHONDIR: "C:\\Python35-x64"
+    PYTHON: "C:\\Python35-x64\\python.exe"
 
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
     PYTHONDIR: "use_conda"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,10 @@ environment:
     PYTHON: "C:\\Python27\\python.exe"
 
   - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
+    PYTHONDIR: "C:\\Python33"
+    PYTHON: "C:\\Python33\\python.exe"
+    
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
     PYTHONDIR: "C:\\Python34"
     PYTHON: "C:\\Python34\\python.exe"
 
@@ -22,6 +26,10 @@ environment:
     PYTHONDIR: "C:\\Python27-x64"
     PYTHON: "C:\\Python27-x64\\python.exe"
 
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
+    PYTHONDIR: "C:\\Python33-x64"
+    PYTHON: "C:\\Python33-x64\\python.exe"
+    
   - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
     PYTHONDIR: "C:\\Python34-x64"
     PYTHON: "C:\\Python34-x64\\python.exe"
@@ -40,6 +48,10 @@ environment:
     PYTHON: "C:\\Python27\\python.exe"
 
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
+    PYTHONDIR: "C:\\Python33"
+    PYTHON: "C:\\Python33\\python.exe"
+    
+  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
     PYTHONDIR: "C:\\Python34"
     PYTHON: "C:\\Python34\\python.exe"
 
@@ -55,6 +67,10 @@ environment:
     PYTHONDIR: "C:\\Python27-x64"
     PYTHON: "C:\\Python27-x64\\python.exe"
 
+  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+    PYTHONDIR: "C:\\Python33-x64"
+    PYTHON: "C:\\Python33-x64\\python.exe"
+    
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
     PYTHONDIR: "C:\\Python34-x64"
     PYTHON: "C:\\Python34-x64\\python.exe"


### PR DESCRIPTION
[3.5 is latest supported Python (I assume PyCall/Travis etc. works with it), 3.3 is no longer officially supported.]

You may also want to skip: "In Julia 0.3, sometimes calling a Python function fails"..

to simplify the README.. as no longer supported (and I assume Julia 0.3 itself about to be unsupported (or used), after 0.5 is released).

[ci skip]